### PR TITLE
v2.x: hwloc: add support for hwloc v1.5

### DIFF
--- a/opal/mca/hwloc/base/hwloc_base_dt.c
+++ b/opal/mca/hwloc/base/hwloc_base_dt.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2011-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -154,8 +156,14 @@ int opal_hwloc_unpack(opal_buffer_t *buffer, void *dest,
 
 int opal_hwloc_copy(hwloc_topology_t *dest, hwloc_topology_t src, opal_data_type_t type)
 {
+#ifdef HAVE_HWLOC_TOPOLOGY_DUP
     /* use the hwloc dup function */
     return hwloc_topology_dup(dest, src);
+#else
+    /* hwloc_topology_dup() was introduced in hwloc v1.8.0.
+     * Note that as of March 2017, opal_hwloc_copy() is not (yet?) used in the code base anywhere. */
+    return OPAL_ERR_NOT_SUPPORTED;
+#endif
 }
 
 int opal_hwloc_compare(const hwloc_topology_t topo1,

--- a/opal/mca/hwloc/base/hwloc_base_util.c
+++ b/opal/mca/hwloc/base/hwloc_base_util.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2014 Intel, Inc. All rights reserved.
- * Copyright (c) 2015-2016 Research Organization for Information Science
+ * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
@@ -1474,6 +1474,7 @@ char* opal_hwloc_base_find_coprocessors(hwloc_topology_t topo)
                              "hwloc:base:find_coprocessors: NONE FOUND IN TOPO"));
         return NULL;
     }
+#if HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC
     /* check the device objects for coprocessors */
     osdev = hwloc_get_obj_by_depth(topo, depth, 0);
     while (NULL != osdev) {
@@ -1497,6 +1498,11 @@ char* opal_hwloc_base_find_coprocessors(hwloc_topology_t topo)
     OPAL_OUTPUT_VERBOSE((5, opal_hwloc_base_framework.framework_output,
                          "hwloc:base:find_coprocessors: hosting coprocessors %s",
                          (NULL == cpstring) ? "NONE" : cpstring));
+#else
+    OPAL_OUTPUT_VERBOSE((5, opal_hwloc_base_framework.framework_output,
+                         "hwloc:base:find_coprocessors: the version of hwloc that Open MPI was built against (v%d.%d.%d) does not support detecting coprocessors",
+                         (HWLOC_API_VERSION>>16)&&0xFF, (HWLOC_API_VERSION>>8)&0xFF, HWLOC_API_VERSION&&0xFF));
+#endif
     return cpstring;
 }
 

--- a/opal/mca/hwloc/external/configure.m4
+++ b/opal/mca/hwloc/external/configure.m4
@@ -1,7 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright (c) 2009-2017 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2014-2016 Research Organization for Information Science
+# Copyright (c) 2014-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
@@ -136,6 +136,13 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
                               [opal_hwloc_external_support=yes],
                               [opal_hwloc_external_support=no])
 
+           AS_IF([test "$opal_hwloc_external_support" = "yes"],
+                 [CPPFLAGS="$CPPFLAGS $opal_hwloc_external_CPPFLAGS"
+                  LDFLAGS="$LDFLAGS $opal_hwloc_external_LDFLAGS"
+                  LIBS="$LIBS $opal_hwloc_external_LIBS"
+                  AC_CHECK_DECLS([HWLOC_OBJ_OSDEV_COPROC], [], [], [#include <hwloc.h>])
+                  AC_CHECK_FUNCS([hwloc_topology_dup])])
+
            CPPFLAGS=$opal_hwloc_external_CPPFLAGS_save
            CFLAGS=$opal_hwloc_external_CFLAGS_save
            LDFLAGS=$opal_hwloc_external_LDFLAGS_save
@@ -162,15 +169,15 @@ AC_DEFUN([MCA_opal_hwloc_external_CONFIG],[
 
            AC_CHECK_HEADERS([infiniband/verbs.h])
 
-           AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
+           AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
            AS_IF([test "$opal_hwloc_dir" != ""],
                  [opal_hwloc_external_CFLAGS_save=$CFLAGS
                   CFLAGS="-I$opal_hwloc_dir/include $opal_hwloc_external_CFLAGS_save"])
            AC_COMPILE_IFELSE(
                [AC_LANG_PROGRAM([[#include <hwloc.h>]],
                    [[
-#if HWLOC_API_VERSION < 0x00010800
-#error "hwloc API version is less than 0x00010800"
+#if HWLOC_API_VERSION < 0x00010500
+#error "hwloc API version is less than 0x00010500"
 #endif
                    ]])],
                [AC_MSG_RESULT([yes])],

--- a/opal/mca/hwloc/hwloc1112/configure.m4
+++ b/opal/mca/hwloc/hwloc1112/configure.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
-# Copyright (c) 2015-2016 Research Organization for Information Science
+# Copyright (c) 2015-2017 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
@@ -176,7 +176,9 @@ AC_DEFUN([MCA_opal_hwloc_hwloc1112_CONFIG],[
     # distclean" infrastructure to work properly).
     AS_IF([test "$opal_hwloc_external" = "yes"],
           [AC_MSG_WARN([using an external hwloc; disqualifying this component])
-           opal_hwloc_hwloc1112_support=no])
+           opal_hwloc_hwloc1112_support=no],
+          [AC_DEFINE([HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC], [1])
+           AC_DEFINE([HAVE_HWLOC_TOPOLOGY_DUP], [1])])
 
     # Done!
     AS_IF([test "$opal_hwloc_hwloc1112_support" = "yes"],


### PR DESCRIPTION
hwloc v1.5 does not support HWLOC_OBJ_OSDEV_COPROC
nor hwloc_topology_dup(), so for this version :
- do not search for coprocessors
- do not try hwloc_topology_dup(), note this is not
  used anywhere in the code base

Thanks Jeff for helping with the wording

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit open-mpi/ompi@7e01be60d9fc1f5ed13be70d1df13c5bf7b126b6)